### PR TITLE
Add GitHub Actions CI workflow for Terraform and Ansible linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - test
+      - prod
+      - ci-cd-testing-framework
+  pull_request:
+    branches:
+      - main
+      - dev
+      - test
+      - prod
+
+jobs:
+  terraform:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.5.0'
+      - name: Terraform Init (no backend)
+        run: terraform init -backend=false
+      - name: Terraform Validate
+        run: terraform validate -no-color
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+
+  ansible:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install Ansible and Ansible-Lint
+        run: |
+          pip install ansible ansible-lint
+      - name: Run Ansible-Lint
+        run: ansible-lint ansible


### PR DESCRIPTION
This pull request adds a GitHub Actions CI workflow (`ci.yml`) that runs Terraform initialization, validation and formatting checks, and Ansible linting using ansible-lint. The workflow is triggered on pushes and pull requests to `main`, `dev`, `test` and `prod` branches, ensuring that infrastructure code and configuration remain consistent and that changes are tested automatically.